### PR TITLE
DEV: Add Dockerfile for vpsearch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM enthought/edm-centos-7
 
-WORKDIR /src
-COPY vpsearch_py3.6_rh6-x86_64.json ./
-RUN edm env import -f vpsearch_py3.6_rh6-x86_64.json vpsearch-env && \
-    edm cache purge --all -y
+WORKDIR /app
+ENV EDM_ROOT_DIRECTORY=/app/edm
 
 COPY . .
+RUN edm env import -f vpsearch_py3.6_rh6-x86_64.json vpsearch-env && \
+    edm cache purge --all -y
 
 RUN yum -y install gcc gcc-c++ && \
     edm run -e vpsearch-env -- pip install --no-deps . -v && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM enthought/edm-centos-7
+
+WORKDIR /src
+COPY vpsearch_py3.6_rh6-x86_64.json ./
+RUN edm env import -f vpsearch_py3.6_rh6-x86_64.json vpsearch-env && \
+    edm cache purge --all -y
+
+COPY . .
+
+RUN yum -y install gcc gcc-c++ && \
+    edm run -e vpsearch-env -- pip install --no-deps . -v && \
+    yum -y remove gcc gcc-c++ && \
+    yum clean all
+
+ENTRYPOINT ["edm", "run", "-e", "vpsearch-env", "--"]

--- a/README.md
+++ b/README.md
@@ -112,20 +112,42 @@ via
   pip install -e .
 ```
 
+### Using Docker
+
+It is possible to build a Docker image that contains vpsearch as well as all of
+its dependencies. This is useful, for example, when integrating vpsearch into a
+workflow manager, like Snakemake, CWL, or WDL.
+
+To build the image, run the following command from the root of this repository:
+```bash
+  docker build . -t vpsearch-image
+```
+
+Once the image has been built, vpsearch can then be run from within a
+container. Assuming you have a FASTA file of target sequences in the file
+`database.fasta` in the current directory, run the following to build a
+vpsearch index:
+```bash
+  docker run -it -v $PWD:/data -t vpsearch-image vpsearch build /data/database.fasta
+```
+
+To query the index for a given FASTA file `query.fasta` of query sequences,
+run:
+```bash
+  docker run -it -v $PWD:/data -t vpsearch-image vpsearch query /data/database.db /data/query.fasta
+```
+
 ### Troubleshooting
 
 The vpsearch package relies on the Parasail C library for alignment. If
 building the package fails because the Parasail library cannot be found, you
 can manually specify the location of the Parasail include files and shared
 object libraries by setting the `PARASAIL_INCLUDE_DIR` and `PARASAIL_LIB_DIR`
-environment variables before building the package:
-```bash
-  export PARASAIL_INCLUDE_DIR=/location/of/parasail/include/files
-  export PARASAIL_LIB_DIR=/location/of/parasail/lib/files
-  pip install -e .
-```
-Note that if Parasail is installed in a non-standard location, you may have to
-set the `LD_LIBRARY_PATH` variable at runtime.
+environment variables before building the package: ```bash export
+PARASAIL_INCLUDE_DIR=/location/of/parasail/include/files export
+PARASAIL_LIB_DIR=/location/of/parasail/lib/files pip install -e .  ``` Note
+that if Parasail is installed in a non-standard location, you may have to set
+the `LD_LIBRARY_PATH` variable at runtime.
 
 ## Implementation notes
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,14 @@ The vpsearch package relies on the Parasail C library for alignment. If
 building the package fails because the Parasail library cannot be found, you
 can manually specify the location of the Parasail include files and shared
 object libraries by setting the `PARASAIL_INCLUDE_DIR` and `PARASAIL_LIB_DIR`
-environment variables before building the package: ```bash export
-PARASAIL_INCLUDE_DIR=/location/of/parasail/include/files export
-PARASAIL_LIB_DIR=/location/of/parasail/lib/files pip install -e .  ``` Note
-that if Parasail is installed in a non-standard location, you may have to set
-the `LD_LIBRARY_PATH` variable at runtime.
+environment variables before building the package:
+```bash
+  export PARASAIL_INCLUDE_DIR=/location/of/parasail/include/files
+  export PARASAIL_LIB_DIR=/location/of/parasail/lib/files
+  pip install -e .
+```
+Note that if Parasail is installed in a non-standard location, you may have to
+set the `LD_LIBRARY_PATH` variable at runtime.
 
 ## Implementation notes
 


### PR DESCRIPTION
This adds a Dockerfile for vpsearch, so that the tool can be run from within a Docker container. This is useful to integrate vpsearch into a workflow manager (in my case, I want to add it to a Snakemake-based workflow).

@rkern Would you be able to give this a review, and merge upon approval?