### PR TITLE
DEV: Build wheels using cibuildwheel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+wheelhouse/
 build/
 vpsearch.egg-info/
 vpsearch/_vpsearch.cpp

--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ represents the linearized tree can only query the database, not build the tree.
 The slower tree-of-nodes implementation can build and query (albeit with more
 overhead).
 
+## Building wheels
+
+Wheels for this package can be built in a platform-independent way using
+[cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/). In a clean
+Python environment, run `pip install cibuildwheel` to install the tool,
+followed by e.g.
+```bash
+  CIBW_BUILD=cp38-manylinux_x86_64 \
+  CIBW_BEFORE_BUILD="./ci/build-parasail.sh" \
+  python -m cibuildwheel --output-dir wheelhouse --platform linux
+```
+to build Python 3.8 wheels for Linux. By varying the build tag, wheels for
+other Python versions can be built. 
+
 ## License
 
 This package is licensed under the [BSD license](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Wheels for this package can be built in a platform-independent way using
 Python environment, run `pip install cibuildwheel` to install the tool,
 followed by e.g.
 ```bash
+  CIBW_BUILD_VERBOSITY=1 \
   CIBW_BUILD=cp38-manylinux_x86_64 \
   CIBW_BEFORE_BUILD="./ci/build-parasail.sh" \
   python -m cibuildwheel --output-dir wheelhouse --platform linux

--- a/ci/build-parasail.sh
+++ b/ci/build-parasail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Download a fixed version of Parasail, compile it, and install to /usr/local.
+# Mainly used to build Linux wheels, inside an appropriate manylinux container.
+
+set -euxo pipefail
+
+PARASAIL_VERSION="2.4.3"
+PARASAIL_URL="https://github.com/jeffdaily/parasail/releases/download/v${PARASAIL_VERSION}/parasail-${PARASAIL_VERSION}.tar.gz"
+
+# Download
+curl -L "${PARASAIL_URL}" -o - | tar xzf -
+
+# Build
+cd "parasail-${PARASAIL_VERSION}"
+autoreconf -fi
+./configure --prefix "/usr/local" && make -j4 && make install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "Cython>=0.28.5",
+    "oldest-supported-numpy",  # https://github.com/scipy/oldest-supported-numpy
+]


### PR DESCRIPTION
Adds a command to the README to build vpsearch wheels.

Under normal circumstances `cibuildwheel` is most useful when it is run automatically from within Travis or GitHub actions, so that it can build wheels for all supported Python versions and platforms. If there is interest (and if GitHub actions can be enabled on the admin side) I can set that up as well. If not, building the wheels manually for Linux also works.