### PR TITLE
DOC: Remove faulty DOI.

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -36,8 +36,7 @@
   author = {Yianilos, Peter},
   year = {1993},
   journal = {Fourth Annual ACM-SIAM Symposium on Discrete Algorithms},
-  volume = {93},
-  doi = {10.1145/313559.313789}
+  volume = {93}
 }
 
 @article{2007-wang-NaiveBayesianClassifier,


### PR DESCRIPTION
One of the DOIs in the JOSS submission proved to be invalid. This PR removes it, as no (correct) DOI seems to have been assigned (I contacted ACM and SIAM about this).﻿
