### PR TITLE
Build macOS wheels for Python 3.10

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.6']
+        python-version: ['3.8']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: "./ci/build-parasail.sh"
-        CIBW_SKIP: "cp310-macosx_* pp3*"
+        CIBW_SKIP: "pp3*"
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl


### PR DESCRIPTION
Fixes #12.

Note that Apple silicon is not supported -- I tried various things to get Parasail to compile correctly (cross-compiling, building a fat library, etc) but to no avail. 