### PR TITLE
Restrict version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools<65.2",
     "wheel",
     "Cython>=0.28.5",
     "oldest-supported-numpy",  # https://github.com/scipy/oldest-supported-numpy


### PR DESCRIPTION
setuptools 65.2 and later is incompatible with current EDM Python runtimes. We're looking into the EDM runtime issue, but in the meantime, a workaround is to restrict the version of setuptools used to build the package.