### PR TITLE
Add status badges to README

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,7 +1,10 @@
 name: Tests
 
 on:
-  pull_request
+  - pull_request
+  - push:
+      branches:
+        - master
 
 jobs:
   tests:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,10 +1,10 @@
 name: Tests
 
 on:
-  - pull_request
-  - push:
-      branches:
-        - master
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 vpsearch - Fast Vantage-Point Tree Search for Sequence Databases
 ----------------------------------------------------------------
 
+[![PyPI version](https://badge.fury.io/py/vpsearch.svg)](https://badge.fury.io/py/vpsearch)
+![Tests status](https://github.com/enthought/vpsearch/actions/workflows/run-tests.yaml/badge.svg?event=push)
+
 This is a package for indexing and querying a sequence database for fast
 nearest-neighbor search by means of [vantage point
 trees](https://en.wikipedia.org/wiki/Vantage-point_tree). For reasonably large


### PR DESCRIPTION
addresses #31 

Adds two badges:
- PyPI package
- Status of tests upon merge to master.

I decided not to add the coverage badge as suggested in #31, as it would require another external service (I'm aware we can generate the badge automatically but then it needs to be hosted somewhere, etc).